### PR TITLE
feat: Setup Multi-node minikube, setup and deploy ArgoCD, deploy applications from ArgoCD

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
                 "redhat.vscode-yaml",
                 "GitHub.copilot",
                 "golang.go",
-                "alexkrechik.cucumberautocomplete"
+                "alexkrechik.cucumberautocomplete",
+                "DavidAnson.vscode-markdownlint"
             ]
         }
     },

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -46,6 +46,7 @@ ignore:
   # linter definitions etc.
   - .hadolint.yml
   - .ls-lint.yml
+  - .markdownlint.yml
   - .yamllint.yml
   - .pre-commit-config.yaml
   - .releaserc

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,10 @@
+---
+MD004:
+  style: consistent
+MD007:
+  indent: 4
+MD013: false
+MD035:
+  style: "---"
+MD046:
+  style: fenced

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,33 +28,23 @@ repos:
         name: lint-yaml
         language: script
         entry: /bin/bash -c 'docker compose up lint-yaml --exit-code-from lint-yaml'
-  - repo: local
-    hooks:
       - id: lint-workflows
         name: lint-workflows
         language: script
         entry: /bin/bash -c 'docker compose up lint-workflows --exit-code-from lint-workflows'
-  - repo: local
-    hooks:
       - id: lint-filenames
         name: lint-filenames
         language: script
         entry: /bin/bash -c 'docker compose up lint-filenames --exit-code-from lint-filenames'
-  - repo: local
-    hooks:
       - id: lint-folders
         name: lint-folders
         language: script
         entry: /bin/bash -c 'docker compose up lint-folders --exit-code-from lint-folders'
-  - repo: local
-    hooks:
       - id: lint-inspec-profile
         name: lint-inspec-profile
         language: script
         entry: /bin/bash -c 'docker compose up lint-inspec-profile --exit-code-from lint-inspec-profile'
-  # - repo: local
-  #   hooks:
-  #     - id: lint-dockerfile
-  #       name: lint-dockerfile
-  #       language: script
-  #       entry: /bin/bash -c 'docker compose up lint-dockerfile --exit-code-from lint-dockerfile'
+      # - id: lint-dockerfile
+      #   name: lint-dockerfile
+      #   language: script
+      #   entry: /bin/bash -c 'docker compose up lint-dockerfile --exit-code-from lint-dockerfile'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,8 @@
         "editor.formatOnSave": true,
         "editor.formatOnPaste": true
     },
+    "files.trimTrailingWhitespace": true,
+    "files.insertFinalNewline": true,
     "cSpell.words": [
         "Vagrantbox"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,10 @@
         "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji",
         "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
     ],
+    "[markdown]": {
+        "editor.formatOnSave": true,
+        "editor.formatOnPaste": true
+    },
     "cSpell.words": [
         "Vagrantbox"
     ]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 # Code of Conduct
+
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
 [Mozilla CoC]: https://github.com/mozilla/diversity
@@ -6,11 +7,13 @@
 [translations]: https://www.contributor-covenant.org/translations
 
 ## Our Pledge
+
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
+
 Examples of behavior that contributes to a positive environment for our
 community include:
 
@@ -29,44 +32,53 @@ Examples of unacceptable behavior include:
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
+
 Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
+
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
+
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <sebastian@sommerfeld.io>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
+
 Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
+
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
+
 **Community Impact**: A violation through a single incident or series of actions.
 
 **Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
+
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
 **Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or
 private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
+
 **Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
+
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
 # Contribute to this Project
+
 [file-issues]: https://github.com/sommerfeld-io/template-repository/issues
 
 ## Code
+
 We're thrilled that you'd like to contribute to this project. You can do this by submitting a pull request.
 
 - Fork and clone the repository
@@ -21,9 +23,11 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 
 ## Bug Reports
+
 We'd love to hear your feedback on this project. Feel free to [submit an issue][file-issues] explaining the bug you've found. Please use the issue template for Bug Reports to ensure that we have all the necessary information to reproduce the bug.
 
 ## Feature Requests
+
 We'd love to hear your feedback on this project. Feel free to [submit an issue][file-issues] explaining your feature request. We're also open to ideas and suggestions for improvements.
 
 To increase the likelihood of your feature request being accepted, please write your request in the form of a user story and add some acceptance criteria (ideally in Given-When-Then syntax).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ubuntu Virtual Machine
+
 [doc-website]: https://sommerfeld-io.github.io/vm-ubuntu
 [github-repo]: https://github.com/sommerfeld-io/vm-ubuntu
 [file-issues]: https://github.com/sommerfeld-io/vm-ubuntu/issues
@@ -12,6 +13,7 @@ This project is a collection of scripts and configuration files to setup a Ubunt
 - [Project Board for Issues and Pull Requests][project-board]
 
 ## Requirements and Features
+
 Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual machine ready for development. By doing this, the virtual machine becomes disposable and can be recreated at any time.
 
 ```kroki-ditaa no-separation=true
@@ -38,30 +40,37 @@ Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual
 The VM represents a sandbox and development environment for Kubernetes-related tasks, proof-of-concepts and experiments. The bootstrap script installs Docker and minikube (among other tools).
 
 ## Provisioning
+
 The provisioning is done by a bootstrap script. The script installs all needed packages and configures the VM. However, some manual steps after running the script might still remain.
 
 A prerequisite is that the VM has internet access and `curl` installed.
 
 - Run Bootstrap script:
+
     ```bash
     sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/bootstrap.sh | bash -
     ```
+
 - Git might still need some configuration - e.g. `git config --global user.email sebastian@sommerfeld.io` and `git config --global user.name sebastian`.
 - d.+: Configure public key on GitHub to allow cloning repositories, pulling and pushing via ssh.
 - Maybe you still need to add your user from inside the VM to the docker group
+
     ```bash
     sudo usermod -aG docker "$USER"
     ```
 
 ## Run locally with Vagrant
+
 To test the provisioning scripts locally, you can use Vagrant. The `Vagrantfile` is already included in this repository. To start/stop the Vagrantbox, simply use the `vagrant.sh` script from the root of this repository (next to the `Vagrantfile`). The `bootstrap.sh` script is used to provision the Vagrantbox.
 
 - Maybe you still need to add the `vagrant` user to the docker group (first connect to the Vagrantbox using `vagrant ssh`)
+
     ```bash
     sudo usermod -aG docker "$USER"
     ```
 
 ## Compliance Tests
+
 This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
 
 On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
@@ -75,6 +84,7 @@ The InSpec binary is installed from the bootstrap script.
 Invoke the test suite by cloning the repository and running `components/test-compliance/run.sh`.
 
 ## Contact
+
 Feel free to contact me via <sebastian@sommerfeld.io> or [raise an issue in this repository][file-issues].
 
 <!-- !    DO NOT EDIT DIRECTLY !!!!!                         -->

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ This project is a collection of scripts and configuration files to setup a Ubunt
 ## Requirements and Features
 Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual machine ready for development. By doing this, the virtual machine becomes disposable and can be recreated at any time.
 
-```kroki-ditaa
-
+```kroki-ditaa no-separation=true
     +----------------+
     |  bootstrap.sh  |
     +---------+------+
@@ -34,7 +33,6 @@ Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual
 |    +----------------+    +----------------+    |
 |                                                |
 +------------------------------------------------+
-
 ```
 
 The VM represents a sandbox and development environment for Kubernetes-related tasks, proof-of-concepts and experiments. The bootstrap script installs Docker and minikube (among other tools).
@@ -66,7 +64,11 @@ To test the provisioning scripts locally, you can use Vagrant. The `Vagrantfile`
 ## Compliance Tests
 This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
 
-On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system.
+On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
+
+```bash
+sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/hardening.sh | bash -
+```
 
 The InSpec binary is installed from the bootstrap script.
 

--- a/README.md
+++ b/README.md
@@ -69,20 +69,6 @@ To test the provisioning scripts locally, you can use Vagrant. The `Vagrantfile`
     sudo usermod -aG docker "$USER"
     ```
 
-## Compliance Tests
-
-This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
-
-On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
-
-```bash
-sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/hardening.sh | bash -
-```
-
-The InSpec binary is installed from the bootstrap script.
-
-Invoke the test suite by cloning the repository and running `components/test-compliance/run.sh`.
-
 ## Contact
 
 Feel free to contact me via <sebastian@sommerfeld.io> or [raise an issue in this repository][file-issues].

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,11 @@
 # Security Policy
 
 ## Supported Versions
+
 We only provide (security) updates for the latest release. This means that we recommend using the Docker images tagged with the latest version or the `latest` tag. Whenever we fix an issue, we release a new version that includes the fix. We do not provide security updates for older versions.
 
 ## Reporting a Vulnerability
+
 We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
 If you would like to report a vulnerability, or have security concerns regarding this project, please do **not** submit an issue. Instead, please email <sebastian@sommerfeld.io>.
@@ -17,6 +19,7 @@ In order for us to best respond to your report, please include any of the follow
 [All issues labeled as `security`](https://github.com/sommerfeld-io/template-repository/issues?q=is%3Aissue+label%3Asecurity%2Crisk+is%3Aopen) tackle already disclosed security issues (e.g. CVEs) and are publicly known already.
 
 ## Detecting Vulnerabilities
+
 We prioritize the security of our project and take proactive measures to detect vulnerabilities. As part of our continuous integration and delivery process, we scan our Docker images using Docker Scout in every pipeline run and for every pull request. This ensures that any potential vulnerabilities are identified and addressed promptly.
 
 <!-- !    DO NOT EDIT DIRECTLY !!!!!                         -->

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", path: "components/provision/bootstrap.sh"
+  config.vm.provision "shell", path: "components/provision/hardening.sh"
   config.vm.provision "shell", path: "components/provision/bootstrap-vagrant.sh", privileged: false
 
   # Fix permissions and ownership because bootstrap.sh is run as root.
@@ -33,7 +34,7 @@ Vagrant.configure("2") do |config|
   # Run inspec tests from script inside Vagrantbox
   config.vm.provision "shell", inline: "(cd /vagrant/components/test-compliance && ./run.sh)", privileged: false
 
-  # Portainer
+  # Portainer from VM
   config.vm.network "forwarded_port", guest: 7990, host: 7990
 
   # minikube port range

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,14 +18,14 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "components/provision/hardening.sh"
   config.vm.provision "shell", path: "components/provision/bootstrap-vagrant.sh", privileged: false
 
-  # Fix permissions and ownership because bootstrap.sh is run as root.
+  # Fix permissions and ownership because bootstrap.sh is run as root
   config.vm.provision "shell", inline: "chown -R vagrant:vagrant /opt/vm-ubuntu"
   config.vm.provision "shell", inline: "chmod -R 755 /opt/vm-ubuntu"
-  config.vm.provision "shell", inline: "chmod -x /opt/vm-ubuntu/portainer/docker-compose.yml"
+  config.vm.provision "shell", inline: "chmod 644 /opt/vm-ubuntu/portainer/docker-compose.yml"
 
-  # Overwrite files from remote repository with local files to allow for local development.
-  # This section copies the files from the local repository to the Vagrant box.
-  # The original files are also available in the Vagrant box in the /vagrant directory.
+  # Overwrite files from remote repository with local files to allow for local development
+  # This section copies the files from the local repository to the Vagrant box
+  # The original files are also available in the Vagrant box in the /vagrant directory
   config.vm.provision "file", source: "components/k8s/minikube-startup.sh", destination: "/opt/vm-ubuntu/minikube-startup.sh"
   config.vm.provision "file", source: "components/k8s/minikube-shutdown.sh", destination: "/opt/vm-ubuntu/minikube-shutdown.sh"
   config.vm.provision "file", source: "components/k8s/minikube-delete.sh", destination: "/opt/vm-ubuntu/minikube-delete.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "components/k8s/minikube-shutdown.sh", destination: "/opt/vm-ubuntu/minikube-shutdown.sh"
   config.vm.provision "file", source: "components/k8s/minikube-delete.sh", destination: "/opt/vm-ubuntu/minikube-delete.sh"
   config.vm.provision "file", source: "components/k8s/minikube-delete.sh", destination: "/opt/vm-ubuntu/minikube-dashboard.sh"
+  config.vm.provision "file", source: "components/k8s/argocd-install.sh", destination: "/opt/vm-ubuntu/argocd-install.sh"
 
   # Run inspec tests from script inside Vagrantbox
   config.vm.provision "shell", inline: "(cd /vagrant/components/test-compliance && ./run.sh)", privileged: false

--- a/components/k8s/argocd-install.sh
+++ b/components/k8s/argocd-install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# @file argocd.sh
+# @brief Bootstrap script to deploy ArgoCD and applications on minikube.
+# @description
+#   This script is used to deploy ArgoCD and applications on minikube. The installation of
+#   minikube, helm, kubectl, etc is done by `bootstrap.sh`.
+#
+#   ArgoCD Autopilot is used to deploy ArgoCD itselt to the Kubernetes cluster. ArgoCD then deploys
+#   the applications from the `XXXXXXXXXXXXXXXXXXXX` directory.
+
+# shellcheck disable=SC1091
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+
+
+export GIT_REPO="https://github.com/sommerfeld-io/vm-ubuntu.git/components/k8s/argocd"
+readonly ARGO_PROJECT="default-project"
+
+
+echo "[INFO] === Github Token ========================================"
+read -spr "Enter Token: " GIT_TOKEN
+export GIT_TOKEN
+readonly GIT_TOKEN
+
+
+echo "[INFO] === Environment ========================================"
+echo "User     = $USER"
+echo "Hostname = $HOSTNAME"
+echo "Home dir = $HOME"
+hostnamectl
+echo "[INFO] === ArgoCD Autopilot version ==========================="
+argocd-autopilot version
+echo "Repo and path = $GIT_REPO"
+echo "[INFO] ========================================================"
+
+
+echo "[INFO] Bootstrap ArgoCD"
+argocd-autopilot repo bootstrap
+
+echo "[INFO] Create Project"
+argocd-autopilot project create "$ARGO_PROJECT"
+
+echo "[INFO] Create Application"
+argocd-autopilot app create hello-world \
+  --app github.com/argoproj-labs/argocd-autopilot/examples/demo-app \
+  -p "$ARGO_PROJECT" \
+  --wait-timeout 2m
+
+
+echo "[INFO] === Login =============================================="
+echo "Execute the port forward command, and browse to"
+echo "http://localhost:8080. You can log in with user: admin, and the"
+echo "password from the previous step."
+echo "[INFO] ========================================================"

--- a/components/k8s/minikube-startup.sh
+++ b/components/k8s/minikube-startup.sh
@@ -4,6 +4,25 @@
 # @description
 #   This script starts minikube and enables the addons metrics-server, dashboard and ingress. The
 #   script starts minikube differently depending on whether it is running in a Vagrantbox or not.
+#
+#   ## Usage
+#   The script accepts a flag "--nodes" to specify the number of nodes to start. The default is 1.
+#
+#   ```bash
+#   ./minikube-startup.sh
+#   ./minikube-startup.sh --nodes 3
+#   ```
+
+
+NODES=1
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        "--nodes") NODES="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+readonly NODES
 
 
 set -o errexit
@@ -27,12 +46,12 @@ fi
 readonly IS_VAGRANT
 
 
-echo "[INFO] Start minikube"
+echo "[INFO] Start minikube with $NODES nodes"
 if [ "$IS_VAGRANT" = true ]; then
   echo "[INFO] with additional configuration for Vagrantbox"
-  minikube start --extra-config=apiserver.service-node-port-range=7000-7080 --extra-config=apiserver.bind-address=0.0.0.0
+  minikube start --nodes "$NODES" --extra-config=apiserver.service-node-port-range=7000-7080 --extra-config=apiserver.bind-address=0.0.0.0
 else
-  minikube start
+  minikube start --nodes "$NODES"
 fi
 
 echo "[INFO] Enable addons"

--- a/components/provision/bootstrap-vagrant.sh
+++ b/components/provision/bootstrap-vagrant.sh
@@ -15,7 +15,7 @@ set -o nounset
 readonly bashrc="$HOME/.bashrc"
 
 
-echo "[INFO] ========================================================"
+echo "[INFO] === Environment ========================================"
 echo "[INFO] Running as user $USER"
 hostnamectl
 echo "[INFO] ========================================================"

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -3,7 +3,7 @@
 # @brief Bootstrap script to provision the Vagrantbox and to install into non-virtual Ubuntu systems.
 # @description
 #   This script is used to provision the Vagrantbox and to install into non-virtual Ubuntu systems.
-#   It installs some basic packages and tools, docker, minikube and helm.
+#   It installs some basic packages and tools, Docker, minikube, Helm, k9s and Inspec.
 
 # shellcheck disable=SC1091
 
@@ -69,16 +69,18 @@ fi
 sudo usermod -aG docker "$USER"
 newgrp docker
 
+echo "[INFO] Test docker"
+docker run --rm hello-world:latest
+
 
 echo "[INFO] Install minikube"
-
-curl -L -o /tmp/minikube-linux-amd64 https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+readonly MINIKUBE_VERSION="latest"
+curl -fsSL -o /tmp/minikube-linux-amd64 https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-amd64
 sudo install /tmp/minikube-linux-amd64 /usr/local/bin/minikube
 rm /tmp/minikube-linux-amd64
 
 
 echo "[INFO] Install helm"
-
 curl -fsSL -o /tmp/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 chmod 700 /tmp/get_helm.sh
 /tmp/get_helm.sh
@@ -87,19 +89,22 @@ rm /tmp/get_helm.sh
 
 echo "[INFO] Install Inspec"
 readonly INSPEC_VERSION="5.22.36"
-curl -o /tmp/inspec.deb "https://packages.chef.io/files/stable/inspec/$INSPEC_VERSION/ubuntu/20.04/inspec_$INSPEC_VERSION-1_amd64.deb"
+curl -fsSL -o /tmp/inspec.deb "https://packages.chef.io/files/stable/inspec/$INSPEC_VERSION/ubuntu/20.04/inspec_$INSPEC_VERSION-1_amd64.deb"
 sudo dpkg -i /tmp/inspec.deb
 rm /tmp/inspec.deb
 sudo apt-get install -y -f
 
 
+echo "[INFO] Install k9s"
+readonly K9S_VERSION="0.32.5"
+curl -fsSL -o /tmp/k9s.deb https://github.com/derailed/k9s/releases/download/v$K9S_VERSION/k9s_linux_amd64.deb
+sudo apt-get install -y /tmp/k9s.deb
+rm /tmp/k9s.deb
+
+
 echo "[INFO] Clean up"
 sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*
-
-
-echo "[INFO] Test docker"
-docker run --rm hello-world:latest
 
 
 echo "[INFO] Setup folders"

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -32,6 +32,7 @@ sudo apt-get install -y apt-transport-https \
   curl \
   gnupg \
   lsb-release \
+  auditd \
   git \
   tilix \
   tmux \

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -3,7 +3,10 @@
 # @brief Bootstrap script to provision the Vagrantbox and to install into non-virtual Ubuntu systems.
 # @description
 #   This script is used to provision the Vagrantbox and to install into non-virtual Ubuntu systems.
-#   It installs some basic packages and tools, Docker, minikube, Helm, k9s and Inspec.
+#   It installs
+#   - some basic packages and tools
+#   - Docker, minikube and helm
+#   - Ansible
 
 # shellcheck disable=SC1091
 
@@ -100,6 +103,13 @@ readonly K9S_VERSION="0.32.5"
 curl -fsSL -o /tmp/k9s.deb https://github.com/derailed/k9s/releases/download/v$K9S_VERSION/k9s_linux_amd64.deb
 sudo apt-get install -y /tmp/k9s.deb
 rm /tmp/k9s.deb
+
+
+echo "[INFO] Install Ansible"
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y --update ppa:ansible/ansible
+sudo aptget install -y ansible
 
 
 echo "[INFO] Clean up"

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -16,7 +16,7 @@ set -o nounset
 # set -o xtrace
 
 
-echo "[INFO] ========================================================"
+echo "[INFO] === Environment ========================================"
 echo "User     = $USER"
 echo "Hostname = $HOSTNAME"
 echo "Home dir = $HOME"

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -106,6 +106,12 @@ sudo apt-get install -y /tmp/k9s.deb
 rm /tmp/k9s.deb
 
 
+echo "[INFO] Install ArgoCD Autopilot"
+VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -fsSL --output - "https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.tar.gz" | tar zx
+mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
+
+
 echo "[INFO] Install Ansible"
 readonly UBUNTU_CODENAME=jammy
 curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -106,10 +106,11 @@ rm /tmp/k9s.deb
 
 
 echo "[INFO] Install Ansible"
+readonly UBUNTU_CODENAME=jammy
+wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
 sudo apt-get update
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y --update ppa:ansible/ansible
-sudo aptget install -y ansible
+sudo apt-get install -y ansible
 
 
 echo "[INFO] Clean up"

--- a/components/provision/bootstrap.sh
+++ b/components/provision/bootstrap.sh
@@ -108,7 +108,7 @@ rm /tmp/k9s.deb
 
 echo "[INFO] Install Ansible"
 readonly UBUNTU_CODENAME=jammy
-wget -O- "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=get&search=0x6125E2A8C77F2818FB7BD15B93C4A3FD7BB9C367" | sudo gpg --dearmour -o /usr/share/keyrings/ansible-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/ansible-archive-keyring.gpg] http://ppa.launchpad.net/ansible/ansible/ubuntu $UBUNTU_CODENAME main" | sudo tee /etc/apt/sources.list.d/ansible.list
 sudo apt-get update
 sudo apt-get install -y ansible

--- a/components/provision/hardening.sh
+++ b/components/provision/hardening.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # @file hardening.sh
-# @brief ..
+# @brief Harden the system by applying security best practices.
 # @description
 #   This script is designed to harden the system by applying security best practices. The goal is
 #   to comply with the <https://github.com/dev-sec/linux-baseline> InSpec profile.

--- a/components/provision/hardening.sh
+++ b/components/provision/hardening.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# @file hardening.sh
+# @brief ..
+# @description
+#   This script is designed to harden the system by applying security best practices. The goal is
+#   to comply with the <https://github.com/dev-sec/linux-baseline> InSpec profile.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+
+echo "[INFO] ========================================================"
+echo "User     = $USER"
+echo "Hostname = $HOSTNAME"
+echo "Home dir = $HOME"
+hostnamectl
+echo "[INFO] ========================================================"
+
+
+target="/etc/login.defs"
+echo "[INFO] Update $target"
+declare -A replacements=(
+    # ["old"]="new"
+    ["UMASK		022"]="UMASK		027"
+    ["PASS_MAX_DAYS	99999"]="PASS_MAX_DAYS	60"
+    ["PASS_MIN_DAYS	0"]="PASS_MIN_DAYS	7"
+    ["UMASK		022"]="UMASK		027"
+    ["UMASK		022"]="UMASK		027"
+    ["UMASK		022"]="UMASK		027"
+)
+for old in "${!replacements[@]}"; do
+    new="${replacements[$old]}"
+    sudo sed -i "s/$old/$new/" "$target"
+done

--- a/components/provision/hardening.sh
+++ b/components/provision/hardening.sh
@@ -34,3 +34,34 @@ for old in "${!replacements[@]}"; do
     new="${replacements[$old]}"
     sudo sed -i "s/$old/$new/" "$target"
 done
+
+
+target="/etc/modprobe.d/dev-sec.conf"
+echo "[INFO] Update $target"
+sudo rm -f "$target"
+declare -a settings=(
+    "install cramfs /bin/true"
+    "install freevxfs /bin/true"
+    "install jffs2 /bin/true"
+    "install hfs /bin/true"
+    "install hfsplus /bin/true"
+    "install udf /bin/true"
+    "install vfat /bin/true"
+)
+for setting in "${settings[@]}"; do
+    echo "$setting" | sudo tee -a "$target"
+done
+sudo chmod 644 "$target"
+
+echo "[INFO] Update cron permissions"
+declare -a cron_config=(
+    "/etc/cron.d"
+    "/etc/crontab"
+    "/etc/cron.hourly"
+    "/etc/cron.daily"
+    "/etc/cron.weekly"
+    "/etc/cron.monthly"
+)
+for cfg in "${cron_config[@]}"; do
+    sudo chmod 711 "$cfg"
+done

--- a/components/provision/hardening.sh
+++ b/components/provision/hardening.sh
@@ -11,7 +11,7 @@ set -o nounset
 # set -o xtrace
 
 
-echo "[INFO] ========================================================"
+echo "[INFO] === Environment ========================================"
 echo "User     = $USER"
 echo "Hostname = $HOSTNAME"
 echo "Home dir = $HOME"

--- a/components/test-compliance/run.sh
+++ b/components/test-compliance/run.sh
@@ -4,6 +4,11 @@
 # @description
 #   This script runs the audit tests defined in the InSpec profile to check if the setup is as
 #   intended.
+#
+#   A custom InSpec profile is used to check the setup. Additionally parts of the
+#   <https://github.com/dev-sec/linux-baseline> are checked as well. Hardware- and network-related
+#   checks are omitted because the setup is a virtual machine. E.g. CPU and network is controlled
+#   by the virtualization software and not by the host system.
 
 
 set -o errexit
@@ -24,7 +29,7 @@ echo "[INFO]   https://sommerfeld-io.github.io/vm-ubuntu"
 echo "[INFO] ========================================================"
 
 
-readonly EXCLUDE_CONTROLS='/^(?!os-14|os-16).*$/'
+readonly EXCLUDE_CONTROLS='/^(?!os-12|os-14|os-15|os-16|sysctl-).*$/'
 PROFILES=(
   'vm-ubuntu'
   'https://github.com/dev-sec/linux-baseline'

--- a/components/test-compliance/run.sh
+++ b/components/test-compliance/run.sh
@@ -26,7 +26,7 @@ echo "[INFO] ========================================================"
 
 PROFILES=(
   'vm-ubuntu'
-  # 'https://github.com/dev-sec/linux-baseline'
+  'https://github.com/dev-sec/linux-baseline'
 )
 for profile in "${PROFILES[@]}"; do
   echo "[INFO] Validate profile $profile"

--- a/components/test-compliance/run.sh
+++ b/components/test-compliance/run.sh
@@ -24,14 +24,15 @@ echo "[INFO]   https://sommerfeld-io.github.io/vm-ubuntu"
 echo "[INFO] ========================================================"
 
 
+readonly EXCLUDE_CONTROLS='/^(?!os-14|os-16).*$/'
 PROFILES=(
   'vm-ubuntu'
   'https://github.com/dev-sec/linux-baseline'
 )
 for profile in "${PROFILES[@]}"; do
   echo "[INFO] Validate profile $profile"
-  inspec check "$profile" --chef-license=accept-no-persist
+  inspec check "$profile" --chef-license accept-no-persist
 
   echo "[INFO] Run profile $profile"
-  inspec exec "$profile" --chef-license=accept-no-persist
+  inspec exec "$profile" --chef-license accept-no-persist --controls "$EXCLUDE_CONTROLS"
 done

--- a/components/test-compliance/run.sh
+++ b/components/test-compliance/run.sh
@@ -39,5 +39,5 @@ for profile in "${PROFILES[@]}"; do
   inspec check "$profile" --chef-license accept-no-persist
 
   echo "[INFO] Run profile $profile"
-  inspec exec "$profile" --chef-license accept-no-persist --controls "$EXCLUDE_CONTROLS"
+  inspec exec "$profile" --chef-license accept-no-persist --controls "$EXCLUDE_CONTROLS" --no-distinct-exit
 done

--- a/components/test-compliance/vm-ubuntu/controls/opt.rb
+++ b/components/test-compliance/vm-ubuntu/controls/opt.rb
@@ -1,9 +1,9 @@
-title "/opt/vm-ubuntu checks"
+title '/opt/vm-ubuntu checks'
 
-control "opt-01" do
+control 'opt-01' do
     impact 0.7
-    title "Scripts should exist and should have correct permissions"
-    desc "Check if scripts exist and have the correct permissions."
+    title 'Scripts should exist and should have correct permissions'
+    desc 'Check if scripts exist and have the correct permissions.'
 
     SCRIPS = %w(
         /opt/vm-ubuntu/minikube-startup.sh
@@ -24,10 +24,10 @@ control "opt-01" do
     end
 end
 
-control "opt-02" do
+control 'opt-02' do
     impact 0.7
-    title "Docker compose files should exist and should have correct permissions"
-    desc "Check if docker compose files exist and have the correct permissions."
+    title 'Docker compose files should exist and should have correct permissions'
+    desc 'Check if docker compose files exist and have the correct permissions.'
 
     FILES = %w(
         /opt/vm-ubuntu/portainer/docker-compose.yml

--- a/components/test-compliance/vm-ubuntu/controls/packages.rb
+++ b/components/test-compliance/vm-ubuntu/controls/packages.rb
@@ -3,7 +3,7 @@ title 'software packages'
 control 'packages-01' do
     impact 1.0
     title 'Packages should be installed'
-    desc 'Software packages should be installed'
+    desc 'Required software packages should be installed'
 
     PACKAGES = %w(
         apt-transport-https
@@ -37,7 +37,7 @@ end
 control 'packages-02' do
     impact 0.5
     title 'Snap packages should be installed'
-    desc 'Snap packages should be installed'
+    desc 'Required snap packages should be installed'
 
     SNAPS = %w(
         /snap/bin/code
@@ -55,7 +55,7 @@ end
 control 'packages-03' do
     impact 1.0
     title 'Binary commands should be installed'
-    desc 'Software packages run from binary commands should be installed'
+    desc 'Required binary commands should be installed'
 
     COMMANDS = %w(
         /usr/local/bin/helm
@@ -74,7 +74,7 @@ end
 control 'packages-99' do
     impact 1.0
     title 'No installation artifacts should remain on the system'
-    desc 'All downloads and scripts and other artifacts should be removed'
+    desc 'No installation artifacts should remain on the system, all downloads and scripts should be removed'
 
     ARTIFACT = %w(
         /tmp/minikube-linux-amd64

--- a/components/test-compliance/vm-ubuntu/controls/packages.rb
+++ b/components/test-compliance/vm-ubuntu/controls/packages.rb
@@ -25,6 +25,7 @@ control 'packages-01' do
         docker-buildx-plugin
         docker-compose-plugin
         inspec
+        k9s
     )
     PACKAGES.each do |p|
         describe package(p) do

--- a/components/test-compliance/vm-ubuntu/controls/packages.rb
+++ b/components/test-compliance/vm-ubuntu/controls/packages.rb
@@ -79,6 +79,7 @@ control 'packages-99' do
         /tmp/minikube-linux-amd64
         /tmp/get_helm.sh
         /tmp/inspec.deb
+        /tmp/k9s.deb
     )
     ARTIFACT.each do |a|
         describe file(a) do

--- a/components/test-compliance/vm-ubuntu/controls/packages.rb
+++ b/components/test-compliance/vm-ubuntu/controls/packages.rb
@@ -61,6 +61,7 @@ control 'packages-03' do
     COMMANDS = %w(
         /usr/local/bin/helm
         /usr/local/bin/minikube
+        /usr/local/bin/argocd-autopilot
     )
     COMMANDS.each do |c|
         describe file(c) do

--- a/components/test-compliance/vm-ubuntu/controls/packages.rb
+++ b/components/test-compliance/vm-ubuntu/controls/packages.rb
@@ -26,6 +26,7 @@ control 'packages-01' do
         docker-compose-plugin
         inspec
         k9s
+        ansible
     )
     PACKAGES.each do |p|
         describe package(p) do

--- a/docs/about/code-of-conduct.md
+++ b/docs/about/code-of-conduct.md
@@ -1,4 +1,5 @@
 # Code of Conduct
+
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
 [Mozilla CoC]: https://github.com/mozilla/diversity
@@ -6,11 +7,13 @@
 [translations]: https://www.contributor-covenant.org/translations
 
 ## Our Pledge
+
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
+
 Examples of behavior that contributes to a positive environment for our
 community include:
 
@@ -29,44 +32,53 @@ Examples of unacceptable behavior include:
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
+
 Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
+
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
+
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <sebastian@sommerfeld.io>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
+
 Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
+
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
+
 **Community Impact**: A violation through a single incident or series of actions.
 
 **Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
+
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
 **Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or
 private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
+
 **Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
+
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].

--- a/docs/about/contribute.md
+++ b/docs/about/contribute.md
@@ -1,7 +1,9 @@
 # Contribute to this Project
+
 [file-issues]: https://github.com/sommerfeld-io/template-repository/issues
 
 ## Code
+
 We're thrilled that you'd like to contribute to this project. You can do this by submitting a pull request.
 
 - Fork and clone the repository
@@ -21,9 +23,11 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write [good commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 
 ## Bug Reports
+
 We'd love to hear your feedback on this project. Feel free to [submit an issue][file-issues] explaining the bug you've found. Please use the issue template for Bug Reports to ensure that we have all the necessary information to reproduce the bug.
 
 ## Feature Requests
+
 We'd love to hear your feedback on this project. Feel free to [submit an issue][file-issues] explaining your feature request. We're also open to ideas and suggestions for improvements.
 
 To increase the likelihood of your feature request being accepted, please write your request in the form of a user story and add some acceptance criteria (ideally in Given-When-Then syntax).

--- a/docs/about/security.md
+++ b/docs/about/security.md
@@ -1,9 +1,11 @@
 # Security Policy
 
 ## Supported Versions
+
 We only provide (security) updates for the latest release. This means that we recommend using the Docker images tagged with the latest version or the `latest` tag. Whenever we fix an issue, we release a new version that includes the fix. We do not provide security updates for older versions.
 
 ## Reporting a Vulnerability
+
 We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
 If you would like to report a vulnerability, or have security concerns regarding this project, please do **not** submit an issue. Instead, please email <sebastian@sommerfeld.io>.
@@ -17,4 +19,5 @@ In order for us to best respond to your report, please include any of the follow
 [All issues labeled as `security`](https://github.com/sommerfeld-io/template-repository/issues?q=is%3Aissue+label%3Asecurity%2Crisk+is%3Aopen) tackle already disclosed security issues (e.g. CVEs) and are publicly known already.
 
 ## Detecting Vulnerabilities
+
 We prioritize the security of our project and take proactive measures to detect vulnerabilities. As part of our continuous integration and delivery process, we scan our Docker images using Docker Scout in every pipeline run and for every pull request. This ensures that any potential vulnerabilities are identified and addressed promptly.

--- a/docs/compliance-tests.md
+++ b/docs/compliance-tests.md
@@ -1,0 +1,18 @@
+---
+hide:
+  - toc
+---
+
+# Compliance Tests
+
+This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
+
+On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
+
+```bash
+sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/hardening.sh | bash -
+```
+
+The InSpec binary is installed from the bootstrap script.
+
+Invoke the test suite by cloning the repository and running `components/test-compliance/run.sh`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 # Ubuntu Virtual Machine
+
 [doc-website]: https://sommerfeld-io.github.io/vm-ubuntu
 [github-repo]: https://github.com/sommerfeld-io/vm-ubuntu
 [file-issues]: https://github.com/sommerfeld-io/vm-ubuntu/issues
@@ -12,6 +13,7 @@ This project is a collection of scripts and configuration files to setup a Ubunt
 - [Project Board for Issues and Pull Requests][project-board]
 
 ## Requirements and Features
+
 Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual machine ready for development. By doing this, the virtual machine becomes disposable and can be recreated at any time.
 
 ```kroki-ditaa no-separation=true
@@ -38,30 +40,37 @@ Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual
 The VM represents a sandbox and development environment for Kubernetes-related tasks, proof-of-concepts and experiments. The bootstrap script installs Docker and minikube (among other tools).
 
 ## Provisioning
+
 The provisioning is done by a bootstrap script. The script installs all needed packages and configures the VM. However, some manual steps after running the script might still remain.
 
 A prerequisite is that the VM has internet access and `curl` installed.
 
 - Run Bootstrap script:
+
     ```bash
     sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/bootstrap.sh | bash -
     ```
+
 - Git might still need some configuration - e.g. `git config --global user.email sebastian@sommerfeld.io` and `git config --global user.name sebastian`.
 - d.+: Configure public key on GitHub to allow cloning repositories, pulling and pushing via ssh.
 - Maybe you still need to add your user from inside the VM to the docker group
+
     ```bash
     sudo usermod -aG docker "$USER"
     ```
 
 ## Run locally with Vagrant
+
 To test the provisioning scripts locally, you can use Vagrant. The `Vagrantfile` is already included in this repository. To start/stop the Vagrantbox, simply use the `vagrant.sh` script from the root of this repository (next to the `Vagrantfile`). The `bootstrap.sh` script is used to provision the Vagrantbox.
 
 - Maybe you still need to add the `vagrant` user to the docker group (first connect to the Vagrantbox using `vagrant ssh`)
+
     ```bash
     sudo usermod -aG docker "$USER"
     ```
 
 ## Compliance Tests
+
 This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
 
 On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
@@ -75,4 +84,5 @@ The InSpec binary is installed from the bootstrap script.
 Invoke the test suite by cloning the repository and running `components/test-compliance/run.sh`.
 
 ## Contact
+
 Feel free to contact me via <sebastian@sommerfeld.io> or [raise an issue in this repository][file-issues].

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,7 @@ This project is a collection of scripts and configuration files to setup a Ubunt
 ## Requirements and Features
 Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual machine ready for development. By doing this, the virtual machine becomes disposable and can be recreated at any time.
 
-```kroki-ditaa
-
+```kroki-ditaa no-separation=true
     +----------------+
     |  bootstrap.sh  |
     +---------+------+
@@ -34,7 +33,6 @@ Automated and fully reproducible setup of a Ubuntu Desktop VM making the virtual
 |    +----------------+    +----------------+    |
 |                                                |
 +------------------------------------------------+
-
 ```
 
 The VM represents a sandbox and development environment for Kubernetes-related tasks, proof-of-concepts and experiments. The bootstrap script installs Docker and minikube (among other tools).

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,20 +69,6 @@ To test the provisioning scripts locally, you can use Vagrant. The `Vagrantfile`
     sudo usermod -aG docker "$USER"
     ```
 
-## Compliance Tests
-
-This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
-
-On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
-
-```bash
-sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/hardening.sh | bash -
-```
-
-The InSpec binary is installed from the bootstrap script.
-
-Invoke the test suite by cloning the repository and running `components/test-compliance/run.sh`.
-
 ## Contact
 
 Feel free to contact me via <sebastian@sommerfeld.io> or [raise an issue in this repository][file-issues].

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,11 @@ To test the provisioning scripts locally, you can use Vagrant. The `Vagrantfile`
 ## Compliance Tests
 This repository provides a [Chef InSpec](https://docs.chef.io/inspec) profile designed to verify the installation of required packages, binaries, and software, ensuring that they are present and correctly installed. The profile checks for essential components, including package installations, the existence and permissions of binaries, and verifies the proper structure of the filesystem. Additionally, it ensures that utility scripts and configurations needed for Minikube are in place as expected.
 
-On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system.
+On top of that, the [dev-sec/linux-baseline](https://github.com/dev-sec/linux-baseline) is executed as well to check the security of the system. For your Ubuntu system to comply with the Linux Baseline, you can run the hardening script from this repository.
+
+```bash
+sudo curl -fsSL https://raw.githubusercontent.com/sommerfeld-io/vm-ubuntu/refs/heads/main/components/provision/hardening.sh | bash -
+```
 
 The InSpec binary is installed from the bootstrap script.
 

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -11,6 +11,46 @@ minikube ships with a `kubectl` binary to interact with the minikube cluster. Ke
 ## Interact with minikube
 The bootstrap script downloads the `components/k8s/minikube-*.sh` scripts from this repo into `/opt/vm-ubuntu`. The scripts are utilities to start / stop / delete minikube with some default settings. minikube startup is slightly different depending on whether it is running in a Vagrantbox or not.
 
+### Running inside a Vagrantbox
+minikube binds itself to `127.0.0.1` (which represents the localhost from inside the Vagrantbox, not from the host). Requests from the host to the VM are not possible unless the `apiserver.bind-address` is changed.
+
+Make sure the Vagrantbox forwards all needed ports to the host.
+
+```bash
+# Startup inside Vagrantbox
+minikube start --extra-config=apiserver.service-node-port-range=7000-7080 --extra-config=apiserver.bind-address=0.0.0.0
+
+# Expose the minikube dashboard on specified port and without opening the browser
+minikube dashboard --port 7999 --url
+```
+
+Since the dashboard (despite setting the bind address) still only answers to requests from inside the Vagrantbox, you need an SSH tunnel to the dashboard inside the Vagrantbox.
+
+```bash
+vagrant ssh -- -L 7999:localhost:7999
+```
+
+`7999` is the port on the host which tunnels to `localhost:7999` inside the Vagrantbox. The port on the host must be a free port, so it cannot be part of the NodePort range.
+
+### Cluster with multiple nodes
+The `minikube-startup.sh` script accepts a flag `--nodes` to specify the number of nodes to start. The default is 1.
+
+```bash
+./minikube-startup.sh
+./minikube-startup.sh --nodes 3
+```
+
+Minikube determines the control plane and worker nodes based on the number of nodes. The control plane is always the first node, and the worker nodes are the rest. The control plane node is the node where the Kubernetes API server is running. The worker nodes are the nodes where the application workloads are scheduled.
+
+#### HAProxy
+*TODO ...* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+*TODO ...* Ditaa / Plantuml diagram
+
+### Increasing the NodePort range
+By default, minikube exposes ports `30000-32767`. If this does not work for you, you can adjust the range by using: `minikube start --extra-config=apiserver.service-node-port-range=1024-65535`
+
+### Example commands
 Some example commands to interact with minikube (which are also used by the scripts):
 
 ```bash
@@ -42,26 +82,5 @@ kubectl -- get po -A
 minikube service list # --namespace apps
 ```
 
-## Interact with minikube when running inside a Vagrantbox
-minikube binds itself to `127.0.0.1` (which represents the localhost from inside the Vagrantbox, not from the host). Requests from the host to the VM are not possible unless the `apiserver.bind-address` is changed.
-
-Make sure the Vagrantbox forwards all needed ports to the host.
-
-```bash
-# Startup inside Vagrantbox
-minikube start --extra-config=apiserver.service-node-port-range=7000-7080 --extra-config=apiserver.bind-address=0.0.0.0
-
-# Expose the minikube dashboard on specified port and without opening the browser
-minikube dashboard --port 7999 --url
-```
-
-Since the dashboard (despite setting the bind address) still only answers to requests from inside the Vagrantbox, you need an SSH tunnel to the dashboard inside the Vagrantbox.
-
-```bash
-vagrant ssh -- -L 7999:localhost:7999
-```
-
-`7999` is the port on the host which tunnels to `localhost:7999` inside the Vagrantbox. The port on the host must be a free port, so it cannot be part of the NodePort range.
-
-## Increasing the NodePort range
-By default, minikube exposes ports `30000-32767`. If this does not work for you, you can adjust the range by using: `minikube start --extra-config=apiserver.service-node-port-range=1024-65535`
+## ArgoCD
+*TODO ...* Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -35,12 +35,14 @@ vagrant ssh -- -L 7999:localhost:7999
 ### Cluster with multiple nodes
 The `minikube-startup.sh` script accepts a flag `--nodes` to specify the number of nodes to start. The default is 1.
 
+Minikube determines the control plane and worker nodes based on the number of nodes. The control plane is always the first node, and the worker nodes are the rest. The control plane node is the node where the Kubernetes API server is running. The worker nodes are the nodes where the application workloads are scheduled.
+
 ```bash
-./minikube-startup.sh
-./minikube-startup.sh --nodes 3
+/opt/vm-ubuntu/minikube-startup.sh
+/opt/vm-ubuntu/minikube-startup.sh --nodes 3
 ```
 
-Minikube determines the control plane and worker nodes based on the number of nodes. The control plane is always the first node, and the worker nodes are the rest. The control plane node is the node where the Kubernetes API server is running. The worker nodes are the nodes where the application workloads are scheduled.
+When you want to change the number of nodes in the minikube cluster, you need to delete the existing cluster and start a new one with the desired number of nodes. Simply stopping and starting the cluster with another number of nodes does not work.
 
 #### HAProxy
 *TODO ...* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -49,6 +51,9 @@ Minikube determines the control plane and worker nodes based on the number of no
 
 ### Increasing the NodePort range
 By default, minikube exposes ports `30000-32767`. If this does not work for you, you can adjust the range by using: `minikube start --extra-config=apiserver.service-node-port-range=1024-65535`
+
+### k9s
+To interact with the cluster, you can use the [`k9s` cli tool](https://k9scli.io) (which is installed through the bootstrap script). It is a terminal-based UI to interact with your Kubernetes clusters. It allows you to navigate and manage your Kubernetes clusters with ease.
 
 ### Example commands
 Some example commands to interact with minikube (which are also used by the scripts):

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -1,17 +1,21 @@
 # Run minikube
+
 [minikube](https://minikube.sigs.k8s.io) is a tool that simplifies running Kubernetes clusters locally. It allows developers to set up a single-node Kubernetes cluster on their local workstation, which is useful for development, testing, and learning purposes. minikube supports various hypervisors (like VirtualBox, KVM, Hyper-V) and container runtimes (like Docker, Podman, containerd, and CRI-O). By providing a local Kubernetes environment, minikube helps developers emulate the behavior of a production cluster, enabling them to test Kubernetes applications in a controlled, local setup before deploying them to a larger, more complex cluster.
 
 [Helm](https://helm.sh) is a package manager for Kubernetes, designed to streamline the deployment, management, and scaling of applications on Kubernetes clusters. It uses "charts",which are packages of pre-configured Kubernetes resources, to define, install, and upgrade Kubernetes applications. Helm helps automate the deployment process, manage dependencies, and simplify updates and rollbacks, making it easier to manage  Kubernetes applications consistently and reproducibly.
 
 ## Prerequisites
+
 minikube requires a virtualization software to run. The default hypervisor is `docker` which is used in this setup.
 
 minikube ships with a `kubectl` binary to interact with the minikube cluster. Keep in mind, that the bootstrap script creates a `kubectl` alias which points to `minikube kubectl` so this might conflict with other `kubectl` installations.
 
 ## Interact with minikube
+
 The bootstrap script downloads the `components/k8s/minikube-*.sh` scripts from this repo into `/opt/vm-ubuntu`. The scripts are utilities to start / stop / delete minikube with some default settings. minikube startup is slightly different depending on whether it is running in a Vagrantbox or not.
 
 ### Running inside a Vagrantbox
+
 minikube binds itself to `127.0.0.1` (which represents the localhost from inside the Vagrantbox, not from the host). Requests from the host to the VM are not possible unless the `apiserver.bind-address` is changed.
 
 Make sure the Vagrantbox forwards all needed ports to the host.
@@ -33,6 +37,7 @@ vagrant ssh -- -L 7999:localhost:7999
 `7999` is the port on the host which tunnels to `localhost:7999` inside the Vagrantbox. The port on the host must be a free port, so it cannot be part of the NodePort range.
 
 ### Cluster with multiple nodes
+
 The `minikube-startup.sh` script accepts a flag `--nodes` to specify the number of nodes to start. The default is 1.
 
 Minikube determines the control plane and worker nodes based on the number of nodes. The control plane is always the first node, and the worker nodes are the rest. The control plane node is the node where the Kubernetes API server is running. The worker nodes are the nodes where the application workloads are scheduled.
@@ -45,17 +50,21 @@ Minikube determines the control plane and worker nodes based on the number of no
 When you want to change the number of nodes in the minikube cluster, you need to delete the existing cluster and start a new one with the desired number of nodes. Simply stopping and starting the cluster with another number of nodes does not work.
 
 #### HAProxy
+
 *TODO ...* Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
 *TODO ...* Ditaa / Plantuml diagram
 
 ### Increasing the NodePort range
+
 By default, minikube exposes ports `30000-32767`. If this does not work for you, you can adjust the range by using: `minikube start --extra-config=apiserver.service-node-port-range=1024-65535`
 
 ### k9s
+
 To interact with the cluster, you can use the [`k9s` cli tool](https://k9scli.io) (which is installed through the bootstrap script). It is a terminal-based UI to interact with your Kubernetes clusters. It allows you to navigate and manage your Kubernetes clusters with ease.
 
 ### Example commands
+
 Some example commands to interact with minikube (which are also used by the scripts):
 
 ```bash
@@ -88,4 +97,5 @@ minikube service list # --namespace apps
 ```
 
 ## ArgoCD
+
 *TODO ...* Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/docs/portainer.md
+++ b/docs/portainer.md
@@ -4,6 +4,7 @@ hide:
 ---
 
 # Run Portainer
+
 The bootstrap script downloads the `components/portainer/docker-compose.yml` script from this repo into `/opt/vm-ubuntu/portainer/docker-compose.yml`.
 
 The portainer password is written from the `docker-compose.yml` file to the local filesystem when starting the stack. The password is written into `portainer.passwd` next to the `docker-compose.yml`.

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -10,10 +10,11 @@ set -o nounset
 readonly OPTION_START="start"
 readonly OPTION_STOP="stop"
 readonly OPTION_SSH="ssh"
+readonly OPTION_SSH_TUNNEL="ssh-tunnel"
 readonly OPTION_DELETE="remove"
 
 
-select o in "$OPTION_START" "$OPTION_SSH" "$OPTION_STOP" "$OPTION_DELETE"; do
+select o in "$OPTION_START" "$OPTION_SSH" "$OPTION_SSH_TUNNEL" "$OPTION_STOP" "$OPTION_DELETE"; do
     case "$o" in
         "$OPTION_START" )
             vagrant validate
@@ -21,6 +22,9 @@ select o in "$OPTION_START" "$OPTION_SSH" "$OPTION_STOP" "$OPTION_DELETE"; do
             break;;
         "$OPTION_SSH" )
             vagrant ssh
+            break;;
+        "$OPTION_SSH_TUNNEL" )
+            vagrant ssh -- -L 7999:localhost:7999
             break;;
         "$OPTION_STOP" )
             vagrant halt


### PR DESCRIPTION
This Pull Request is focused on setting up a multi-node Minikube cluster and configuring ArgoCD for deployment management within the cluster. The primary objectives include:

- **Multi-node Minikube setup**: Configuring Minikube to run with multiple nodes if desired to simulate a production-like Kubernetes environment. This provides a more robust testing and development setup compared to single-node clusters.
- **HAProxy setup**: Starting HAProxy to load balance and serve content from all nodes in the Minikube cluster, ensuring high availability and traffic distribution across the nodes.
- **ArgoCD configuration**: Installing and configuring ArgoCD on the Minikube cluster to handle continuous delivery, allowing automated synchronization of the Kubernetes manifests from a repository to the Minikube environment. 
- **Applications**: Some demo applications are deployed into the cluster.
- **Test**: Gatlin puts some load on the cluster so it is possible to test the behavior e.g. when some replicas are terminated.